### PR TITLE
Add support for Scriptable Rendering Pipelines

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,6 +3,7 @@ root = true
 [*]
 end_of_line = lf
 charset = utf-8
+insert_final_newline = true
 trim_trailing_whitespace = true
 
 [*.{asmdef,cs}]

--- a/README.md
+++ b/README.md
@@ -6,14 +6,17 @@ Alternative to [Texture2D.Apply()](https://docs.unity3d.com/ScriptReference/Text
 
 ## Features
 - Asynchronous texture data update in CPU in the render thread, avoiding stalls in the main thread
-- Updates run before the first camera renders, guaranteeing the texture is applied before appearing in the screen
+- Supports Unity's Built-in Render Pipeline as well as Scriptable Render Pipelines (e.g: URP and HDRP).
+- To guarante the texture is applied before appearing in the screen:
+  + In BRP, updates are scheduled in the first Camera's `Camera.onPreRender` event
+  + In SRP, updates are scheduled in `RenderPipelineManager.beginContextRendering` event
 - Supports registering for updates every frame or for a single frame
 - Prebuilt for Windows, Linux, macOS and Android
 - Built from source in iOS, tvOS, visionOS and WebGL projects
 
 
 ## Caveats
-- You should not update the texture's data while the camera is rendering, or else garbage data could be applied to the texture.
+- You should not update the texture's data while the camera/render pipeline is rendering, or else garbage data could be applied to the texture.
 
 
 ## How to install

--- a/Runtime/Internal/TextureAsyncApplier.cs
+++ b/Runtime/Internal/TextureAsyncApplier.cs
@@ -1,3 +1,6 @@
+#if UNITY_2021_1_OR_NEWER
+    #define HAVE_RENDER_PIPELINE_MANAGER_BEGIN_CONTEXT_RENDERING
+#endif
 using System;
 using System.Collections.Generic;
 using UnityEngine;
@@ -16,7 +19,11 @@ namespace Gilzoide.TextureApplyAsync.Internal
         private static bool _isOnPreRenderRegistered;
 
         private static int HandlesCount => _applyHandlesEveryFrame.Count + _applyHandlesThisFrame.Count;
+#if UNITY_2019_3_OR_NEWER
         private static bool IsUsingScriptableRenderPipeline => GraphicsSettings.currentRenderPipeline != null;
+#else
+        private static bool IsUsingScriptableRenderPipeline => GraphicsSettings.renderPipelineAsset != null;
+#endif
 
         public static void ScheduleUpdateEveryFrame(TextureApplyAsyncHandle handle)
         {
@@ -95,7 +102,11 @@ namespace Gilzoide.TextureApplyAsync.Internal
         {
             if (IsUsingScriptableRenderPipeline)
             {
+#if HAVE_RENDER_PIPELINE_MANAGER_BEGIN_CONTEXT_RENDERING
                 RenderPipelineManager.beginContextRendering += CachedOnBeginContextRendering;
+#else
+                RenderPipelineManager.beginFrameRendering += CachedOnBeginFrameRendering;
+#endif
             }
             else
             {
@@ -108,7 +119,11 @@ namespace Gilzoide.TextureApplyAsync.Internal
         {
             if (IsUsingScriptableRenderPipeline)
             {
+#if HAVE_RENDER_PIPELINE_MANAGER_BEGIN_CONTEXT_RENDERING
                 RenderPipelineManager.beginContextRendering -= CachedOnBeginContextRendering;
+#else
+                RenderPipelineManager.beginFrameRendering -= CachedOnBeginFrameRendering;
+#endif
             }
             else
             {
@@ -197,8 +212,13 @@ namespace Gilzoide.TextureApplyAsync.Internal
 
         #region Scriptable Render Pipeline
 
+#if HAVE_RENDER_PIPELINE_MANAGER_BEGIN_CONTEXT_RENDERING
         private static readonly Action<ScriptableRenderContext, List<Camera>> CachedOnBeginContextRendering = OnBeginContextRendering;
         private static void OnBeginContextRendering(ScriptableRenderContext context, List<Camera> cameras)
+#else
+        private static readonly Action<ScriptableRenderContext, Camera[]> CachedOnBeginFrameRendering = OnBeginFrameRendering;
+        private static void OnBeginFrameRendering(ScriptableRenderContext context, Camera[] cameras)
+#endif
         {
             if (HandlesCount == 0)
             {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "author": {
     "name": "Gil Barbosa Reis"
   },
-  "unity": "2018.3",
+  "unity": "2019.1",
   "samples": [
     {
         "displayName": "Random colors",


### PR DESCRIPTION
`TextureAsyncApplier` now uses `RenderPipelineManager`'s callbacks to execute the `CommandBuffer` in a `ScriptableRenderContext` instead of Camera. This happens automatically based on the current render pipeline asset: if there is none, it falls back to scheduling command buffers in the first Camera that gets rendered.

Fixes #3.