### PR TITLE
Bump minimal Unity version to 2021.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "author": {
     "name": "Gil Barbosa Reis"
   },
-  "unity": "2019.1",
+  "unity": "2021.2",
   "samples": [
     {
         "displayName": "Random colors",


### PR DESCRIPTION
We are already using null-coalescing operators, which are only available in Unity 2021.2+