### PR TITLE
Add support for reinitializing handle after reinitializing textures

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,14 @@ textureApplyAsyncHandle.ScheduleUpdateOnce();
 // Works for both one-shot and every frame updates.
 textureApplyAsyncHandle.CancelUpdates();
 
-// 6. Dispose of the `TextureApplyAsyncHandle` when not needed
+// 6. If you ever Reinitialize your Texture, make
+// sure to Reinitialize your TextureApplyAsyncHandle
+// or your app may crash!!!
+myTexture.Reinitialize(width, height);
+myTexture.Apply();
+textureApplyAsyncHandle.Reinitialize();
+
+// 7. Dispose of the `TextureApplyAsyncHandle` when not needed
 // anymore, e.g. inside a component's `OnDestroy`.
 textureApplyAsyncHandle.Dispose();
 ```

--- a/Runtime/Internal/TextureAsyncApplier.cs
+++ b/Runtime/Internal/TextureAsyncApplier.cs
@@ -70,6 +70,19 @@ namespace Gilzoide.TextureApplyAsync.Internal
             }
         }
 
+        public static bool IsRegistered(TextureApplyAsyncHandle handle)
+        {
+            return _applyHandlesEveryFrame.Contains(handle) || _applyHandlesThisFrame.Contains(handle);
+        }
+
+        internal static void MarkDirty(TextureApplyAsyncHandle handle)
+        {
+            if (!_isCommandBufferDirty)
+            {
+                _isCommandBufferDirty = IsRegistered(handle);
+            }
+        }
+
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
         private static void InitializeOnLoad()
         {

--- a/Runtime/TextureApplyAsyncHandle.cs
+++ b/Runtime/TextureApplyAsyncHandle.cs
@@ -15,16 +15,8 @@ namespace Gilzoide.TextureApplyAsync
 
         public TextureApplyAsyncHandle(Texture2D texture)
         {
-            if (texture == null)
-            {
-                throw new ArgumentNullException(nameof(texture));
-            }
-
             Texture = texture;
-            unsafe
-            {
-                Id = NativeBridge.RegisterHandle((IntPtr) Texture.GetRawTextureData<byte>().GetUnsafeReadOnlyPtr());
-            }
+            Reinitialize();
         }
 
         ~TextureApplyAsyncHandle()
@@ -45,6 +37,24 @@ namespace Gilzoide.TextureApplyAsync
         public void CancelUpdates()
         {
             TextureAsyncApplier.Unregister(this);
+        }
+
+        public void Reinitialize()
+        {
+            if (Texture == null)
+            {
+                throw new ArgumentNullException(nameof(Texture));
+            }
+
+            if (Id != 0)
+            {
+                NativeBridge.UnregisterHandle(Id);
+            }
+            unsafe
+            {
+                Id = NativeBridge.RegisterHandle((IntPtr) Texture.GetRawTextureData<byte>().GetUnsafeReadOnlyPtr());
+            }
+            TextureAsyncApplier.MarkDirty(this);
         }
 
         public void FillCommandBuffer(CommandBuffer commandBuffer)

--- a/Samples~/PlasmaColorJob/PlasmaTextureAsyncUpdater.cs
+++ b/Samples~/PlasmaColorJob/PlasmaTextureAsyncUpdater.cs
@@ -25,21 +25,41 @@ public class PlasmaTextureAsyncUpdater : MonoBehaviour
     {
         if (_texture == null)
         {
-            _texture = new Texture2D(width, height, TextureFormat.RGBA32, false, false);
+            _texture = new Texture2D(width, height, TextureFormat.RGBA32, false, false)
+            {
+                name = name
+            };
+            rawImage.texture = _texture;
         }
-        rawImage.texture = _texture;
+        else
+        {
+            _texture.Reinitialize(width, height, TextureFormat.RGBA32, false);
+            _texture.Apply();
+        }
         _textureApplyAsyncHandle = new TextureApplyAsyncHandle(_texture);
     }
 
     void OnDisable()
     {
-        _textureApplyAsyncHandle?.Dispose();
+        _textureApplyAsyncHandle.Dispose();
     }
 
     void OnDestroy()
     {
         Destroy(_texture);
     }
+
+#if UNITY_EDITOR
+    void OnValidate()
+    {
+        if (isActiveAndEnabled && _texture)
+        {
+            _texture.Reinitialize(width, height, TextureFormat.RGBA32, false);
+            _texture.Apply();
+            _textureApplyAsyncHandle.Reinitialize();
+        }
+    }
+#endif
 
     void Update()
     {


### PR DESCRIPTION
This adds the `TextureApplyAsyncHandle.Reinitialize` method that should be called manually after reinitializing the target texture of a handle. This avoids crashing the app because of accessing freed memory on the native plugin.

The PlasmaColorJob sample scene uses this with `OnValidate`, so you can change the texture's width/height in editor and it will get properly reinitialized.

Fixes #5.